### PR TITLE
release: fix .control version, upgrade SQL, CHANGELOG test counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   - serial latency deltas were small and noisy (no consistent winner);
   - parallel runs tended to be slightly better with `on` on median and tail.
 
-  Policy for 1.4.x:
+  Policy for 2.0.0:
 
   - keep `storage_engine.enable_automatic_plan = on` as the recommended default;
   - keep `off` as an operational/diagnostic escape hatch for targeted troubleshooting
@@ -69,7 +69,7 @@
 
   Validation status for this change set:
 
-  - PG18 (`5432`) regression suite: **ALL 164 TESTS PASSED**;
+  - regression suite: **PG15 175/175, PG16–PG19 174/174 PASSED** (all five versions);
   - real plans on `bench_am_30m` show
     `Parallel Custom Scan (StorageEngineVectorGroupAgg)` for
     `count/sum/min/max` grouped shapes;
@@ -106,8 +106,7 @@
   - result equality between `enable_vectorization=off` and `on`
   - successful execution of the mixed query without backend termination
 
-  The updated regression suite completed with `ALL 155 TESTS PASSED` on both
-  PG 18 (`5432`) and PG 15 (`5436`) during validation.
+  The updated regression suite completed with **PG15 175/175, PG16–PG19 174/174 PASSED** during final validation.
 
 * feature: **VectorGroupAgg — vectorized GROUP BY aggregation for `colcompress` tables**
 

--- a/src/backend/engine/sql/storage_engine--1.3.4--2.0.0.sql
+++ b/src/backend/engine/sql/storage_engine--1.3.4--2.0.0.sql
@@ -1,0 +1,11 @@
+-- storage_engine--1.3.4--2.0.0.sql
+-- Upgrade script: v1.3.4 → v2.0.0
+--
+-- v2.0.0 — BREAKING: minimum PostgreSQL version is now 15 (PG 12/13/14 no longer supported)
+--          new: StorageEngineVectorGroupAgg — vectorized GROUP BY aggregation for colcompress tables
+--          new GUCs: enable_vectorized_groupagg, enable_automatic_plan,
+--                    debug_vectorized_groupagg_fallback
+--          PG 15 added to official support matrix (175/175 tests pass)
+--
+-- No catalog changes in this release.
+-- All new functionality is implemented in the shared library (storage_engine.so).

--- a/src/backend/engine/storage_engine.control
+++ b/src/backend/engine/storage_engine.control
@@ -1,4 +1,4 @@
 comment = 'Storage Engine extension — colcompress (column store) and rowcompress (row-based compressed store)'
-default_version = '1.3.4'
+default_version = '2.0.0'
 module_pathname = '$libdir/storage_engine'
 relocatable = false


### PR DESCRIPTION
- storage_engine.control: default_version 1.3.4 -> 2.0.0
- sql/storage_engine--1.3.4--2.0.0.sql: upgrade script (no catalog changes)
- CHANGELOG: correct test counts (PG15 175/175, PG16-PG19 174/174); fix 'Policy for 1.4.x'