### PR TITLE
docs: highlight VecGroupAgg v2.0 in README and META.json

### DIFF
--- a/META.json
+++ b/META.json
@@ -1,7 +1,7 @@
 {
    "name": "storage_engine",
-   "abstract": "Column-oriented (colcompress) and row-compressed (rowcompress) Table Access Methods for PostgreSQL with vectorized execution and parallel scan",
-   "description": "storage_engine provides two high-performance Table Access Methods: colcompress (columnar, vectorized, MergeTree-style sort key, stripe-level and chunk-level min/max pruning, parallel DSM scan) and rowcompress (batch-compressed rows, parallel work-stealing scan). Both AMs use zstd by default and coexist safely with heap tables. All catalog objects live in the engine schema; C symbols use the se_ prefix.",
+   "abstract": "Columnar (colcompress) and row-compressed (rowcompress) Table AMs for PostgreSQL with vectorized GROUP BY aggregation, parallel scan, and zone-map pruning",
+   "description": "storage_engine v2.0 introduces StorageEngineVectorGroupAgg — a vectorized GROUP BY aggregate executor that replaces HashAggregate/GroupAggregate with a batch-oriented HTAB pipeline for COUNT, SUM, MIN, MAX, and AVG over colcompress tables, including parallel partial mode on PG 15–19. The extension also provides colcompress (columnar, MergeTree-style sort key, stripe and chunk-level min/max pruning, parallel DSM scan) and rowcompress (batch-compressed rows, parallel work-stealing scan). Both AMs use zstd by default and coexist safely with heap tables. All catalog objects live in the engine schema; C symbols use the se_ prefix.",
    "version": "2.0.0",
    "release_status": "stable",
    "maintainer": [
@@ -10,7 +10,7 @@
    "license": "agpl_3",
    "provides": {
       "storage_engine": {
-         "abstract": "colcompress and rowcompress Table Access Methods with vectorized execution",
+         "abstract": "colcompress and rowcompress Table AMs with vectorized GROUP BY aggregation (v2.0), parallel scan, and zone-map pruning",
          "file": "src/backend/engine/sql/storage_engine--1.0.sql",
          "docfile": "README.md",
          "version": "2.0.0"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # storage_engine
 
+> **v2.0 — Vectorized GROUP BY Aggregation** `storage_engine` now ships `StorageEngineVectorGroupAgg`, a batch-oriented vectorized aggregate executor that transparently replaces `HashAggregate`/`GroupAggregate` for `GROUP BY` queries over `colcompress` tables. Supports `COUNT(*)`, `COUNT(col)`, `SUM`, `MIN`, `MAX`, and `AVG` across all integer, float, and numeric types. Parallel partial mode (`AGGSPLIT_INITIAL_SERIAL`) works on PG 15–19. Validated: **175/175 on PG 15, 174/174 on PG 16–19**.
+
 A PostgreSQL extension providing two high-performance Table Access Methods designed for analytical and HTAP workloads.
 
-- **`colcompress`** — column-oriented compressed storage with vectorized execution and parallel scan
+- **`colcompress`** — column-oriented compressed storage with vectorized execution, **vectorized GROUP BY aggregation**, and parallel scan
 - **`rowcompress`** — row-oriented batch-compressed storage with parallel scan
 
 Both AMs coexist alongside standard heap tables in the same database. All catalog objects are isolated in the `engine` schema, making the extension safe to install alongside `citus_columnar` or any other columnar extension (all exported C symbols carry the `se_` prefix to avoid linker conflicts).
@@ -106,6 +108,25 @@ SET storage_engine.enable_column_cache = on;   -- default: on
 ### Vectorized Execution
 
 `colcompress` ships a **vectorized expression evaluation engine** that processes WHERE clauses and aggregates in column-oriented batches of up to 10,000 values per call, instead of row-at-a-time evaluation. This maps naturally onto column chunks and eliminates per-row interpreter overhead.
+
+#### Vectorized GROUP BY Aggregation (v2.0)
+
+`storage_engine` v2.0 introduces **`StorageEngineVectorGroupAgg`** — a custom aggregate executor node that transparently replaces `HashAggregate` and `GroupAggregate` for `GROUP BY` queries over `colcompress` tables. The planner hooks intercept supported plans and substitute the vectorized path with no SQL changes required.
+
+- Supported aggregates: `COUNT(*)`, `COUNT(col)` (NULL-aware), `SUM`, `MIN`, `MAX`, `AVG`
+- Supported types: `int2`, `int4`, `int8`, `float4`, `float8`, `numeric`, `money`, `engine.uint8`
+- Up to 4 `GROUP BY` keys; constant-key plans (`numCols=0`) are also handled
+- **Parallel partial mode**: runs inside parallel workers via `AGGSPLIT_INITIAL_SERIAL`, feeding the native `Finalize GroupAggregate` combine step
+- Automatic fallback to native `Agg` for unsupported shapes (HAVING, subquery targets, unsupported types)
+
+```sql
+SET storage_engine.enable_vectorized_groupagg = on;   -- default: on
+SET storage_engine.enable_automatic_plan = on;        -- auto-select vectorized path (default: on)
+```
+
+> **Tip:** set `storage_engine.debug_vectorized_groupagg_fallback = on` to log why a given plan fell back to native aggregation.
+
+#### Vectorized Filter Evaluation
 
 Supported vectorized operations:
 


### PR DESCRIPTION
Update abstract, description and README to prominently feature the new vectorized GROUP BY aggregation (StorageEngineVectorGroupAgg) introduced in v2.0.